### PR TITLE
Implementation improvements

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,8 +1,12 @@
-1.3.0 / 2017-02-19
+## 1.3.6 / 2018-08-30
+
+ * Implementation changed
+ 
+## 1.3.0 / 2017-02-19
 
  * Added `eventNames`
 
-1.2.2 / 2017-02-19
+## 1.2.2 / 2017-02-19
 
  * Optimized emit
  * Fixed memory leak

--- a/Readme.md
+++ b/Readme.md
@@ -73,6 +73,14 @@ Emitter(User.prototype);
 
   Returns an array listing the events for which the emitter has registered listeners.
 
+## Tests
+
+`npm t`
+
+or
+
+` ./node_modules/.bin/mocha --require should --reporter spec`
+ 
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ Emitter.prototype.emit = function(event){
   var callbacks = this._callbacks[event];
   
   if (callbacks) {
-	var args = Array.prototype.slice.call(arguments, 1);
+    var args = Array.prototype.slice.call(arguments, 1);
     callbacks = callbacks.slice(0);
     for (var i = 0, len = callbacks.length; i < len; ++i) {
       callbacks[i].apply(this, args);

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ if (typeof module !== 'undefined') {
  */
 
 function Emitter(obj) {
+  (obj || this)._callbacks = Object.create(null);
   if (obj) return mixin(obj);
 };
 
@@ -43,7 +44,6 @@ function mixin(obj) {
 
 Emitter.prototype.on =
 Emitter.prototype.addEventListener = function(event, fn){
-  this._callbacks = this._callbacks || Object.create(null);
   (this._callbacks[event] = this._callbacks[event] || [])
     .push(fn);
   return this;
@@ -84,10 +84,9 @@ Emitter.prototype.off =
 Emitter.prototype.removeListener =
 Emitter.prototype.removeAllListeners =
 Emitter.prototype.removeEventListener = function(event, fn){
-  this._callbacks = this._callbacks || Object.create(null);
 
   // all
-  if (0 == arguments.length) {
+  if (0 === arguments.length) {
     this._callbacks = Object.create(null);
     return this;
   }
@@ -130,16 +129,10 @@ Emitter.prototype.removeEventListener = function(event, fn){
  */
 
 Emitter.prototype.emit = function(event){
-  this._callbacks = this._callbacks || Object.create(null);
-
-  var args = new Array(arguments.length - 1)
-    , callbacks = this._callbacks[event];
-
-  for (var i = 1; i < arguments.length; i++) {
-    args[i - 1] = arguments[i];
-  }
-
+  var callbacks = this._callbacks[event];
+  
   if (callbacks) {
+	var args = Array.prototype.slice.call(arguments, 1);
     callbacks = callbacks.slice(0);
     for (var i = 0, len = callbacks.length; i < len; ++i) {
       callbacks[i].apply(this, args);
@@ -158,7 +151,6 @@ Emitter.prototype.emit = function(event){
  */
 
 Emitter.prototype.listeners = function(event){
-  this._callbacks = this._callbacks || Object.create(null);
   return this._callbacks[event] || [];
 };
 
@@ -181,5 +173,5 @@ Emitter.prototype.hasListeners = function(event){
  * @api public
  */
 Emitter.prototype.eventNames = function(){
-  return this._callbacks ? Object.keys(this._callbacks) : [];
+  return Object.keys(this._callbacks);
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "component-emitter2",
   "description": "Event emitter",
-  "version": "1.3.3",
+  "version": "1.3.6",
   "license": "MIT",
   "devDependencies": {
     "mocha": "*",

--- a/test/emitter.js
+++ b/test/emitter.js
@@ -153,7 +153,6 @@ describe('Emitter', function(){
       emitter.on('foo', cb);
       emitter.off('foo', cb);
 
-	  console.log(emitter._callbacks);
       should(emitter._callbacks).not.have.property('foo');
     })
 

--- a/test/emitter.js
+++ b/test/emitter.js
@@ -1,5 +1,6 @@
-
 var Emitter = require('..');
+
+// should(emitter._callbacks) because it has no prototype
 
 function Custom() {
   Emitter.call(this)
@@ -152,7 +153,8 @@ describe('Emitter', function(){
       emitter.on('foo', cb);
       emitter.off('foo', cb);
 
-      emitter._callbacks.should.not.have.property('$foo');
+	  console.log(emitter._callbacks);
+      should(emitter._callbacks).not.have.property('foo');
     })
 
     it('should only remove the event array when the last subscriber unsubscribes', function() {
@@ -166,7 +168,7 @@ describe('Emitter', function(){
       emitter.on('foo', cb2);
       emitter.off('foo', cb1);
 
-      emitter._callbacks.should.have.property('$foo');
+      should(emitter._callbacks).have.property('foo');
     })
   })
 


### PR DESCRIPTION
An emitter always has ._callbacks , not just after first .on() or .off()
This change alone makes every other function faster.

Use === instead of == when it makes sense
simplified Emitter.prototype.emit
 and made it faster especially when no callbacks are registered for the event

total file size is smaller, also fixed the tests